### PR TITLE
chore: migrate to Policyfile

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+name 'iis_urlrewrite'
+
+default_source :supermarket
+
+run_list 'recipe[iis_urlrewrite::default]'
+
+named_run_list :default, 'recipe[iis_urlrewrite::default]'
+
+cookbook 'iis_urlrewrite', path: '.'

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -9,7 +9,8 @@ transport:
   elevated: true
 
 provisioner:
-  name: chef_zero
+  name: policyfile_zero
+  policyfile: Policyfile.rb
   deprecations_as_errors: true
 
 platforms:
@@ -22,5 +23,5 @@ platforms:
 
 suites:
   - name: default
-    run_list:
-      - recipe[iis_urlrewrite::default]
+    provisioner:
+      named_run_list: default

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
 require 'chefspec'
-require 'chefspec/berkshelf'
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT


### PR DESCRIPTION
## Summary
- replace the Berksfile with a local-root Policyfile and default named run list
- remove the Berkshelf-only ChefSpec require
- use Chef Policyfile resolution in Copilot setup

## Verification
- `chef install Policyfile.rb` passed
- `cookstyle` passed
- `markdownlint-cli2 "**/*.md"` passed
- `yamllint .` passed
- `actionlint` passed
- `kitchen list` passed
- `Policyfile.lock.json` is ignored and untracked
- ChefSpec is blocked locally by the workstation json native-extension code-signature error
- Windows Kitchen integration is delegated to GitHub Actions because no Windows runner is available locally

## Scope
This is a dependency-resolution migration only. Recipes, attributes, and platform support are unchanged.